### PR TITLE
Better accessability and added content to header:contents 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM kthse/kth-nodejs:9.11.0
 
-MAINTAINER KTH Webb "cortina.developers@kth.se"
-
 RUN mkdir -p /npm && \
     mkdir -p /application
 

--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -18,7 +18,7 @@ module.exports = {
     /**
      * Message keys
      */
-    service_name: 'Node application name',
+    service_name: 'Course syllabus pdf-converter',
 
     example_message_key: 'This is an english translation of a label',
 

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -59,6 +59,7 @@ function * getSyllabus (req, res, next) {
       'base': 'https://www.kth.se',
       'type': 'pdf',
       'phantomPath': '/usr/bin/phantomjs',
+      'title': `${syllabusHTML.footerText}`,
       'timeout': 30000
     }
 

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -65,6 +65,7 @@ function * getSyllabus (req, res, next) {
       'timeout': 30000
     }
     console.log('syllabusHTML', pdfConfig.title, pdfConfig.locale)
+    res.setHeader('Content-Type', 'text/html')
     res.send({ syllabusHTML, pdfConfig })
   } catch (err) {
     next(err)

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -44,7 +44,7 @@ function * getSyllabus (req, res, next) {
       paginationOffset: 1, // Override the initial pagination number
       'header': {
         'height': '15mm',
-        'contents': '            '
+        'contents': 'www.kth.se'
       },
       'footer': {
         'height': '27mm',
@@ -64,7 +64,7 @@ function * getSyllabus (req, res, next) {
       lang: language,
       'timeout': 30000
     }
-    console.log('syllabusHTML', pdfConfig.title, pdfConfig.locale)
+
     res.setHeader('Content-Type', 'text/html')
     res.send({ syllabusHTML, pdfConfig })
   } catch (err) {

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -44,7 +44,7 @@ function * getSyllabus (req, res, next) {
       paginationOffset: 1, // Override the initial pagination number
       'header': {
         'height': '15mm',
-        'contents': 'www.kth.se'
+        'contents': '<span style="color:white;display:none;">www.kth.se</span>'
       },
       'footer': {
         'height': '27mm',

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -44,7 +44,7 @@ function * getSyllabus (req, res, next) {
       paginationOffset: 1, // Override the initial pagination number
       'header': {
         'height': '15mm',
-        'contents': ''
+        'contents': '            '
       },
       'footer': {
         'height': '27mm',

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -44,7 +44,7 @@ function * getSyllabus (req, res, next) {
       paginationOffset: 1, // Override the initial pagination number
       'header': {
         'height': '15mm',
-        'contents': '<span style="color:white;display:none;">www.kth.se</span>'
+        'contents': '<span style="color:white;display:none;"></span>'
       },
       'footer': {
         'height': '27mm',

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -44,7 +44,7 @@ function * getSyllabus (req, res, next) {
       paginationOffset: 1, // Override the initial pagination number
       'header': {
         'height': '15mm',
-        'contents': ''
+        'contents': 'hello'
       },
       'footer': {
         'height': '27mm',
@@ -59,10 +59,12 @@ function * getSyllabus (req, res, next) {
       'base': 'https://www.kth.se',
       'type': 'pdf',
       'phantomPath': '/usr/bin/phantomjs',
-      'title': `${syllabusHTML.footerText}`,
+      title: `${syllabusHTML.footerText}`,
+      locale: language,
+      lang: language,
       'timeout': 30000
     }
-
+    console.log('syllabusHTML', pdfConfig.title, pdfConfig.locale)
     res.send({ syllabusHTML, pdfConfig })
   } catch (err) {
     next(err)

--- a/server/controllers/syllabusCtrl.js
+++ b/server/controllers/syllabusCtrl.js
@@ -44,7 +44,7 @@ function * getSyllabus (req, res, next) {
       paginationOffset: 1, // Override the initial pagination number
       'header': {
         'height': '15mm',
-        'contents': 'hello'
+        'contents': ''
       },
       'footer': {
         'height': '27mm',


### PR DESCRIPTION
- better accessability for pdf config
- contents in header must not be empty so added empty 'span' to avoid sigmentation error