### PR TITLE
deps(KUI-1768): bump om-kursen-ladok-client to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@kth/kth-node-api-common": "^2.0.4",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "^1.1.2",
+        "@kth/om-kursen-ladok-client": "^1.2.1",
         "@kth/server": "^4.1.0",
         "@react-pdf/renderer": "^3.4.5",
         "body-parser": "^1.20.3",
@@ -2828,14 +2828,14 @@
       }
     },
     "node_modules/@kth/ladok-attributvarde-utils": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-0.0.11.tgz",
-      "integrity": "sha512-bUfMNXrw7ZvAX1LZmoEOUC9zEMTDNjqTNat1T5GHFule37/x1LgGxnOxi/bGwZqx0K7X9VDenBKHT0ZftNS4Uw=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-0.1.0.tgz",
+      "integrity": "sha512-GMUB1PLg4boODIcw4JMQJVApBCICFeo3CLqc2+O+4dtgpEiMPc4UXXc+VvliPoPRG0fZoydnXaOH/RQyUm3S0w=="
     },
     "node_modules/@kth/ladok-mellanlager-client": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-0.1.2.tgz",
-      "integrity": "sha512-SlgcbeXYz9S3XsyqLoM5vLKrYIWNJAEY+KeGuCp6eikLoVeKEzd2r9MpwD+f8F2XKzaxL3wRfgwTksZOrUGvdA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-0.3.0.tgz",
+      "integrity": "sha512-MBs+sFimeLQkB1eOohKNHTPqsOWgEaceHiNnppyyMj/JBqzqjnTfr/PU89niz+UElHgx6XMVRt8TqBFtzs1s/Q==",
       "dependencies": {
         "openapi-fetch": "^0.13.0"
       }
@@ -2860,12 +2860,12 @@
       }
     },
     "node_modules/@kth/om-kursen-ladok-client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-1.1.2.tgz",
-      "integrity": "sha512-khD6culX6yW/uyShYdMdNSuq/INaE6E9Nrnp+g+5Vk0NUNvGf/wSqnCua7GWew4tIt8qBVcwP3lUs88fqsOPPA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-1.2.1.tgz",
+      "integrity": "sha512-URQs/pH9AgWCwYnT0Wixh471+neerQa9ytZqfXtAKph3aGKZT+fSSXrhXiRDTCNVoc0ze3t9vieC3++YhjBcFg==",
       "dependencies": {
-        "@kth/ladok-attributvarde-utils": "0.0.11",
-        "@kth/ladok-mellanlager-client": "0.1.2",
+        "@kth/ladok-attributvarde-utils": "0.1.0",
+        "@kth/ladok-mellanlager-client": "0.3.0",
         "date-fns": "^4.1.0",
         "showdown": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "kth-node-express-routing": "^2.2.0",
     "kth-node-i18n": "^1.0.18",
     "kth-node-redis": "^3.3.0",
-    "@kth/om-kursen-ladok-client": "^1.1.2",
+    "@kth/om-kursen-ladok-client": "^1.2.1",
     "passport": "^0.7.0",
     "react": "^17.0.2",
     "safe-utils": "1.0.1",


### PR DESCRIPTION
I've tested it locally and it seems to work fine.