### PR TITLE
feat(KUI-1472): remove special logics for preparatory educational level

### DIFF
--- a/.env.in
+++ b/.env.in
@@ -7,3 +7,9 @@ UG_REST_API_SUBSCRIPTION_KEY=[Available in Azure KeyVault]
 
 LADOK_AUTH_CLIENT_SECRET=[Available in Azure KeyVault]
 LADOK_OCP_APIM_SUBSCRIPTION_KEY=[Available in Azure KeyVault]
+
+LADOK_AUTH_SCOPE=api://4afd7e46-019e-44e1-9630-12fdf9d31d02/.default
+LADOK_AUTH_TOKEN_URL=https://login.microsoftonline.com/acd7f330-d613-48d9-85f2-258b1ac4a015/oauth2/v2.0/token
+
+LADOK_BASE_URL=https://ladok-mellanlagring-lab.azure-api.net
+LADOK_OCP_APIM_SUBSCRIPTION_KEY=[Available in Azure KeyVault]

--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -47,7 +47,7 @@ module.exports = {
   cache: {},
 
   ladokMellanlagerApi: {
-    clientId: getEnv('LADOK_AUTH_CLIENT_ID', devDefaults('c978bff4-80c6-42d2-8d64-a6d90227013b')),
+    clientId: getEnv('LADOK_AUTH_CLIENT_ID', null),
     clientSecret: getEnv('LADOK_AUTH_CLIENT_SECRET', null),
     tokenUrl: getEnv(
       'LADOK_AUTH_TOKEN_URL',

--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -67,12 +67,6 @@ module.exports = {
     course_language: 'Language of instruction',
     course_required_equipment: 'Equipment',
     course_level_code: 'Education cycle',
-    course_level_code_label: {
-      PREPARATORY: 'Pre-university level',
-      BASIC: 'First cycle',
-      ADVANCED: 'Second cycle',
-      RESEARCH: 'Third cycle'
-    },
     course_department: 'Offered by',
     course_contact_name: 'Contact ',
     course_suggested_addon_studies: 'Recommended prerequisites',

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -68,12 +68,6 @@ module.exports = {
     course_language: 'Undervisningsspråk',
     course_required_equipment: 'Utrustning',
     course_level_code: 'Utbildningsnivå',
-    course_level_code_label: {
-      PREPARATORY: 'Förberedande nivå',
-      BASIC: 'Grundnivå',
-      ADVANCED: 'Avancerad nivå',
-      RESEARCH: 'Forskarnivå'
-    },
     course_department: 'Ges av',
     course_contact_name: 'Kontaktperson',
     course_suggested_addon_studies: 'Rekommenderade förkunskaper',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@kth/kth-node-api-common": "^2.0.4",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "^1.2.5",
+        "@kth/om-kursen-ladok-client": "^1.3.2",
         "@kth/server": "^4.1.0",
         "@react-pdf/renderer": "^3.4.5",
         "body-parser": "^1.20.3",
@@ -2828,14 +2828,14 @@
       }
     },
     "node_modules/@kth/ladok-attributvarde-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-0.1.0.tgz",
-      "integrity": "sha512-GMUB1PLg4boODIcw4JMQJVApBCICFeo3CLqc2+O+4dtgpEiMPc4UXXc+VvliPoPRG0fZoydnXaOH/RQyUm3S0w=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-0.1.1.tgz",
+      "integrity": "sha512-H1FKpzrhWY5KTA11qcwfI9AVARaBkC5KLO6puoBimwM6uyxPdkkX1leYUPLl0o14in3nz5HvLw6iTYCZ34956w=="
     },
     "node_modules/@kth/ladok-mellanlager-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-0.3.0.tgz",
-      "integrity": "sha512-MBs+sFimeLQkB1eOohKNHTPqsOWgEaceHiNnppyyMj/JBqzqjnTfr/PU89niz+UElHgx6XMVRt8TqBFtzs1s/Q==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-0.4.1.tgz",
+      "integrity": "sha512-gQNkLsdJy64/EiT7COthw1fMjPD/IpHsCpkU4E9RzA9GGAgiUfK1F3YAHXMejsha7ge0DBJxeDc8p9ZqaBsj7w==",
       "dependencies": {
         "openapi-fetch": "^0.13.0"
       }
@@ -2860,12 +2860,12 @@
       }
     },
     "node_modules/@kth/om-kursen-ladok-client": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-1.2.5.tgz",
-      "integrity": "sha512-T9f/Yd2zSkKPQ+HswxUXWhHph7HfEHdABgPRzOS9jr0dWXlSLOUtsqJgFFL/xMlRaxfLhwR+mSuWSu9LFilfZA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-1.3.2.tgz",
+      "integrity": "sha512-X63CqrcuuVi6AHb/nyDe3/bn8+1ug29lJWNFETBAJxVXaKfM09w2kqXnb3QM/45DN2teSG2A5d+4t2kHNvuOrA==",
       "dependencies": {
-        "@kth/ladok-attributvarde-utils": "0.1.0",
-        "@kth/ladok-mellanlager-client": "0.3.0",
+        "@kth/ladok-attributvarde-utils": "0.1.1",
+        "@kth/ladok-mellanlager-client": "0.4.1",
         "date-fns": "^4.1.0",
         "showdown": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "kth-node-express-routing": "^2.2.0",
     "kth-node-i18n": "^1.0.18",
     "kth-node-redis": "^3.3.0",
-    "@kth/om-kursen-ladok-client": "^1.2.5",
+    "@kth/om-kursen-ladok-client": "^1.3.2",
     "passport": "^0.7.0",
     "react": "^17.0.2",
     "safe-utils": "1.0.1",

--- a/server/components-dist/SyllabusKeyInformation.js
+++ b/server/components-dist/SyllabusKeyInformation.js
@@ -22,13 +22,9 @@ var SyllabusKeyInformation = function SyllabusKeyInformation(_ref) {
   var languageIndex = language === 'en' ? 0 : 1;
   var course = syllabus.course;
   var betygsskala = course.betygsskala;
-  var courseLevelCodeTextForPreparatory = {
-    sv: 'Förberedande nivå',
-    en: 'Pre-university level'
-  };
   var courseGradeHeader = _i18n["default"].messages[languageIndex].courseInformation.course_grade_label;
   var courseLevelCodeHeader = _i18n["default"].messages[languageIndex].courseInformation.course_level_code;
-  var courseLevelCodeText = course.nivainomstudieordning.code === 'FUPKURS' ? courseLevelCodeTextForPreparatory[language] : course.nivainomstudieordning.level[language];
+  var courseLevelCodeText = course.nivainomstudieordning.level[language];
   var mainSubjectHeader = _i18n["default"].messages[languageIndex].courseInformation.course_main_subject;
   return /*#__PURE__*/_react["default"].createElement(_renderer.View, null, /*#__PURE__*/_react["default"].createElement(_renderer.Text, {
     style: _SyllabusStyles["default"].h2

--- a/server/components/SyllabusKeyInformation.jsx
+++ b/server/components/SyllabusKeyInformation.jsx
@@ -16,17 +16,10 @@ const SyllabusKeyInformation = ({ syllabus, language }) => {
   const languageIndex = language === 'en' ? 0 : 1
   const { course } = syllabus
   const { betygsskala } = course
-  const courseLevelCodeTextForPreparatory = {
-    sv: 'Förberedande nivå',
-    en: 'Pre-university level',
-  }
 
   const courseGradeHeader = i18n.messages[languageIndex].courseInformation.course_grade_label
   const courseLevelCodeHeader = i18n.messages[languageIndex].courseInformation.course_level_code
-  const courseLevelCodeText =
-    course.nivainomstudieordning.code === 'FUPKURS'
-      ? courseLevelCodeTextForPreparatory[language]
-      : course.nivainomstudieordning.level[language]
+  const courseLevelCodeText = course.nivainomstudieordning.level[language]
   const mainSubjectHeader = i18n.messages[languageIndex].courseInformation.course_main_subject
 
   return (


### PR DESCRIPTION
New PR for https://github.com/KTH/kursplan-api/pull/328 _because history got too messy and I couldn't fix it_:

Flyttat hårdkodad logik för förberedande utbildningsnivå till studadm-om-kursen-packages/ladok-attributvarde-utils: https://github.com/KTH/studadm-om-kursen-packages/pull/61/files

Exempel på olika utbildningsnivå för att testa denna PR:

* Förberedande: HF0025 http://localhost:3001/api/kursplan/v1/syllabus/HF0025/20242/sv
* Grundnivå: SF1624 http://localhost:3001/api/kursplan/v1/syllabus/SF1624/20242/sv
* Avancerad nivå: LH216V http://localhost:3001/api/kursplan/v1/syllabus/LH216V/20242/sv
* Forskarnivå: FME3532 http://localhost:3001/api/kursplan/v1/syllabus/FME3532/20242/sv