### PR TITLE
KUI-1793: Fix bug where PDF for syllabus can't be opened

### DIFF
--- a/server/components/SyllabusKeyInformation.jsx
+++ b/server/components/SyllabusKeyInformation.jsx
@@ -31,7 +31,7 @@ const SyllabusKeyInformation = ({ syllabus, language }) => {
       {showMainSubject(course) && (
         <View>
           <Text style={styles.h2}>{`${mainSubjectHeader}`}</Text>
-          <Text style={styles.bodyText}>{`${course.huvudomraden.map(item => item[language]).join(', ')}`}</Text>
+          <Text style={styles.bodyText}>{`${course.huvudomraden?.map(item => item[language]).join(', ')}`}</Text>
         </View>
       )}
     </View>


### PR DESCRIPTION
Susanne reported that the pdf for a course syllabus could not be opened. This change should handle the case where huvudomraden doesn't exist.